### PR TITLE
Added option to Untie boat inside walk

### DIFF
--- a/english/explore-outside/journey-to-flaming-tower/walk/Untie-boat/untie-boat.md
+++ b/english/explore-outside/journey-to-flaming-tower/walk/Untie-boat/untie-boat.md
@@ -1,0 +1,5 @@
+You untie the boat, but it turns out that there are no oars to propel the boat.
+
+What will you do?
+
+ 

--- a/english/explore-outside/journey-to-flaming-tower/walk/walk.md
+++ b/english/explore-outside/journey-to-flaming-tower/walk/walk.md
@@ -3,3 +3,9 @@ You eventually come to a river. There is a bridge, and the road
 continues toward the tower which appears no closer.
 
 Beneath the bridge you see a dock with a boat tied up.  
+
+Do you:
+
+[Go down and untie the boat](./Untie-boat/untie-boat.md)
+
+[Try other methods](../journey-to-flaming-tower.md)


### PR DESCRIPTION
The option to untie the boat inside the /create-your-own-adventure/english/explore-outside/journey-to-flaming-tower/walk/ directory has been added.
