### PR TITLE
Add basement-swim page linked from  eating-chocolate page

### DIFF
--- a/english/light-fire/sprinkler/basement-swim/basement-swim.md
+++ b/english/light-fire/sprinkler/basement-swim/basement-swim.md
@@ -1,5 +1,3 @@
 You dive into the pool of chocolate in your Olympic-sized basement
-
 and start swimming laps to work off all those marshmallows you've
-
 been eating.

--- a/english/light-fire/sprinkler/eating-chocolate.md
+++ b/english/light-fire/sprinkler/eating-chocolate.md
@@ -3,7 +3,6 @@ The chocolate sprinkler extinguishes the burning marshmallow walls.
 You start eating caramelized, chocolate-covered marshmallows.
 
 After you're finished eating, you notice the sprinkler flooded the
-
 basement, making a pool of chocolate. Do you:
 
 [Go back to sleep](../../sleep/more-sleep/more-sleep.md)?


### PR DESCRIPTION
I modified 'english/light-fire/sprinkler/eating-chocolate.md'. Now the basement is flooded with chocolate and there is one more choice (swim in the chocolate pool), which means there is another subdirectory and page added (basement-swim/basement-swim.md).
