### PR TITLE
Correct spelling of marshmellow to marshmallow

### DIFF
--- a/english/count-the-marshmellows/count-the-marshmellows.md
+++ b/english/count-the-marshmellows/count-the-marshmellows.md
@@ -1,4 +1,4 @@
-You count the marshmellows which relaxes you and you fall asleep, afterwards you wake up and you must make a decision.
+You count the marshmallows which relaxes you and you fall asleep, afterwards you wake up and you must make a decision.
 
 Do you:
 
@@ -6,6 +6,6 @@ Do you:
 
 [Look for a way out?](../find-exit/leave.md)
 
-[Sell the marshmellows on ebay?] (./sell-on-ebay/sell-on-ebay.md)
+[Sell the marshmallows on ebay?] (./sell-on-ebay/sell-on-ebay.md)
 
-[Eat ALL the marshmellows](./eat-all-the-marshmellows/eat-all-the-marshmellows.md)
+[Eat ALL the marshmallows](./eat-all-the-marshmellows/eat-all-the-marshmellows.md)

--- a/english/count-the-marshmellows/eat-all-the-marshmellows/eat-all-the-marshmellows.md
+++ b/english/count-the-marshmellows/eat-all-the-marshmellows/eat-all-the-marshmellows.md
@@ -1,3 +1,3 @@
-you eat ALL of the marshmellows. Emeril Lagasse appears and shouts "BAM!"
+you eat ALL of the marshmallows. Emeril Lagasse appears and shouts "BAM!"
 
 you explode.

--- a/english/count-the-marshmellows/sell-on-ebay/sell-on-ebay.md
+++ b/english/count-the-marshmellows/sell-on-ebay/sell-on-ebay.md
@@ -1,5 +1,5 @@
-You list the marshmellows in packages of 100 on ebay.  
-A popup advertises a dessert courier service "Candy Couriers". 
+You list the marshmallows in packages of 100 on ebay.  
+A popup advertises a dessert courier service "Candy Couriers".
 They sell like hotcakes.  How do you get the marshmellows to the buyers?
 
 
@@ -10,5 +10,3 @@ Do you:
 [Look for an exit to try to deliver them by hand](../../find-exit/leave.md)
 
 [Hire a Candy Courier] (./hire-a-candy-courier/hire-a-candy-courier.md)
-
-

--- a/english/marshmallow.md
+++ b/english/marshmallow.md
@@ -20,7 +20,7 @@ Do you:
 
 [Look for a way out?](find-exit/leave.md)
 
-[Count the marshmellows?](count-the-marshmellows/count-the-marshmellows.md)
+[Count the marshmallows?](count-the-marshmellows/count-the-marshmellows.md)
 
 [Begin to dance to pass the time?](dance/dance.md)
 


### PR DESCRIPTION
marshmallow was miss-spelled as marshmellow on several places.
