### PR TITLE
Fixed typo in opening page

### DIFF
--- a/english/marshmallow.md
+++ b/english/marshmallow.md
@@ -10,7 +10,7 @@ But it's probably not worth dwelling on that right now, you could be in danger.
 
 These marshmallows are numerous and they look so delicious.
 
-You reach out to grab a handful of the marshmallow wall, but you can seem to take the handful away from the wall.
+You reach out to grab a handful of the marshmallow wall, but you can't seem to take the handful away from the wall.
 
 You also seem to be wearing an uncomfortable and restrictive jacket made of leather...
 


### PR DESCRIPTION
In the english opening page, there's a "can" that should be a "can't".