### PR TITLE
Change swedish start to enable other swedish options

### DIFF
--- a/swedish/marshmallowen/marshmallowen.md
+++ b/swedish/marshmallowen/marshmallowen.md
@@ -1,0 +1,7 @@
+Efter två tuggor bli du väldigt trött igen.
+
+Huvudet vrider sig och dina tanker bullra.
+
+Du märker att du har börjat tänker på engelska. Din svenska försvinner.
+
+[Du blunda och huvudet träffar kudden.](../../english/marshmallow.md)

--- a/swedish/start.md
+++ b/swedish/start.md
@@ -3,5 +3,10 @@ Ett förfärligt oväsen - mörkret lättar.
 Du har sovit dåligt, förföljd i dina mardrömmar hela natten. Du stänger väckarklockan och sätter
 dig upp. Drömmen, vad hände egentligen? Allting känns så främmande.
 
-Främmande, precis som dina egna tankar. Du inser att du tänker på engelska och blir förvirrad.
-[Du ser dig omkring i rummet.](../english/marshmallow.md)
+Plötsligt inser du att rummet som du ligger i är inte ditt.
+
+På sängbord sitter en stor marshmallow och på marshmallowen står orden "Eat me for English". Konstigt.
+
+Vad nu, då?
+
+[Äter marshmallowen.](marshmallowen/marshmallowen.md)


### PR DESCRIPTION
I changed the starting text in the swedish version to preserve the path to the english version but to also make it easier for others to start some story branched in swedish from the /swedish/start.md.