### PR TITLE
Fix typo in english/marshmallow.md

### DIFF
--- a/english/marshmallow.md
+++ b/english/marshmallow.md
@@ -76,7 +76,7 @@ Do you:
 
 [Watch the Warriors vs Cavaliers game 1 of the NBA Finals](warriors-game/watch-warriors.md)
 
-[Peak through the keyhole to reveal what is beyond](world-war-marshmallows/world-war-marshmallows.md)
+[Peek through the keyhole to reveal what is beyond](world-war-marshmallows/world-war-marshmallows.md)
 
 [Try the more effective "Apparation" spell to teleport elsewhere](movie-ripoffs/hogwarts/hogwarts.md)
 


### PR DESCRIPTION
Correction: "Peak" to "Peek"

@cbuckey-uda Here is a nice clean diff with 1 commit. To use instead of #1507.