### PR TITLE
Fix typo in shelter.md

### DIFF
--- a/english/forest/shelter/shelter.md
+++ b/english/forest/shelter/shelter.md
@@ -1,4 +1,4 @@
 You break down some branches and make a frame. You put your parachute over
-the top of it, tying it down securly with palm leaves. Luckily you did it 
+the top of it, tying it down securely with palm leaves. Luckily you did it 
 because as you make yourself comfortable for the night the heaven's open. 
 There's a terrible storm brewing... 


### PR DESCRIPTION
Fixed typo in **securely** as it was misspelled.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/create-your-own-adventure/1979)
<!-- Reviewable:end -->
