### PR TITLE
Add whole-new-world story

### DIFF
--- a/english/coffee/procrastinate/procrastinate.md
+++ b/english/coffee/procrastinate/procrastinate.md
@@ -2,4 +2,5 @@ As you sit there and sip your coffee pondering over this huge marshmallow proble
 you strike upon a golden idea! Why hadn't you thought of this before?
 Procrastinate!! Well, That seems to work every time you want to avoid a problem.
 You flip out your phone and tap on that little twitter icon and voila!
-Problems just disappear and you are in a whole new world!
+Problems just disappear and you are in a [whole new
+world!](./whole-new-world/whole-new-world.md)

--- a/english/coffee/procrastinate/whole-new-world/whole-new-world.md
+++ b/english/coffee/procrastinate/whole-new-world/whole-new-world.md
@@ -1,0 +1,17 @@
+Alas, not even Twitter is safe from this madness! As you scroll through the
+feed, you notice your awareness narrowing into the screen, losing any sense
+of the rest of the world...
+
+...was the screen always that big?...
+
+...why are the pixels so close, now?...
+
+...was it really Twitter you were on? You don't remember switching, but you
+don't feel the phone in your hand, anymore...
+
+Suddenly, you find yourself in device-which-may-or-may-not-be-your-phone,
+looking out of the screen. Are you in a [Virtual
+Reality?](./../../../virtualreality/oculus.md) Perhaps you have [fallen into
+Minecraft.](./../../../you-are-in-minecraft/minecraft.md)
+
+


### PR DESCRIPTION
Whole-new-world story added to english/coffee/procrastinate. Add option for whole-new-world in procrastinate. Options in whole-new-world direct to two preexisting stories.

All links tested, they function as expected.

Casey can not pull this, since I modify a line to introduce an option.