### PR TITLE
Add check_source_team to ghost-stories

### DIFF
--- a/english/invite-friends/camp_fire/ghost-stories/check_source_team/check_source_team.md
+++ b/english/invite-friends/camp_fire/ghost-stories/check_source_team/check_source_team.md
@@ -1,0 +1,6 @@
+You and your friends go to the next room. Because you were the one to suggest this, you enter the room first. Inside,
+you see that a huge part of the marshmallow wall has been torn down. A trail of blood leads through the hole and your
+grandmother who had been watching tv is missing.
+
+You think to yourself: "Grandmother, no! What should I do now!?"
+

--- a/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
+++ b/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
@@ -9,4 +9,4 @@ Do you:
 
 [Scare yourself to death and ask someone to go check where the scream came from](scared/scared.md)
 
-[Suggest to your friends that you had better go to the next room together to find out what happened](check_source_team/check_source.md)
+[Suggest to your friends that you had better go to the next room together to find out what happened](check_source_team/check_source_team.md)

--- a/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
+++ b/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
@@ -8,3 +8,5 @@ Do you:
 [Become the hero and tell everyone that you are going to see where the scream comes from](check_source/check_source.md)
 
 [Scare yourself to death and ask someone to go check where the scream came from](scared/scared.md)
+
+[Suggest to your friends that you had better go to the next room together to find out what happened](check_source_team/check_source.md)

--- a/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
+++ b/english/invite-friends/camp_fire/ghost-stories/ghost-stories.md
@@ -9,4 +9,5 @@ Do you:
 
 [Scare yourself to death and ask someone to go check where the scream came from](scared/scared.md)
 
-[Suggest to your friends that you had better go to the next room together to find out what happened](check_source_team/check_source_team.md)
+[Suggest to your friends to go investigate together to see what happened](check_source_team/check_source_team.md)
+


### PR DESCRIPTION
Create a new link in /english/invite-friends/camp_fire/ghost-stories/ghost-stories.md and create a new directory check_source_team with its own md file. Choose file name consistent with alternating naming pattern ("-" vs "_", I realise "-" is preferred, sorry!).