### PR TITLE
Remove typo Fishe and add bigger teeth and big appetite

### DIFF
--- a/german/Kopfsprung/Kopfsprung.md
+++ b/german/Kopfsprung/Kopfsprung.md
@@ -2,7 +2,7 @@ Sie springen ins Wasser und holen die Hose zurück.
 
 Im Wasser sehen Sie, dass ihr Boot auf ein Riff aufgelaufen ist.
 Das Riff ist mit wunderschönen Korallen bewachsen, welche eine bunte Schar Fische beheimatet.
-Die Fishe haben große Zähne und die Fische haben Hunger.
+Die Fische haben sehr große Zähne und die Fische haben Hunger. Großen Hunger.
 
 Werden Sie:
 


### PR DESCRIPTION
Changed the word "Fishe" into "Fische" and added bigger teeth and a big appetite to make it sound more dangerous.