### PR TITLE
fix: fixed typo in frapper-le-mur.md

### DIFF
--- a/french/panique/frapper-le-mur.md
+++ b/french/panique/frapper-le-mur.md
@@ -2,7 +2,7 @@ Alors que vous laissez la panique s'emparer de vous, vous commencez à courir da
 
 Finalement, emporté par votre élan, vous finissez par frapper un mur et vous vous écroulez à terre. Bien joué !
 
-Maintenat que vous etes dehors, quoi faire?
+Maintenat que vous êtes dehors, quoi faire?
 
 [Je sens des fleurs](sentir/fleurs.md)
 


### PR DESCRIPTION
fix: fixed typo in frapper-le-mur.md

'etes' should be 'êtes'