### PR TITLE
Fix link and add 5 lines

### DIFF
--- a/english/forest/drag/skull/skull.md
+++ b/english/forest/drag/skull/skull.md
@@ -1,3 +1,8 @@
 As u pick up the skull a string detaches from it and suddenly everything turns black.
 
 As u regain vision u see youself in an empty white place with two paths.
+
+To your left is a forest trail covered in snow with a faraway sign reading
+"Ma's Place".
+The way to your right is a tube of whorling rainbow smoke. Your skin crawls at
+the sound of faint giggling far in the distance.

--- a/english/lovecraftian/shoggoth.md
+++ b/english/lovecraftian/shoggoth.md
@@ -5,4 +5,4 @@ This really hurts.
 
 But just then you:
 
-[See an ostrich?] (../hospital_bed/hospital_bed.md)
+[See an ostrich?](../hospital_bed/hospital_bed.md)


### PR DESCRIPTION
This fixes a link in english/lovecraftian/shoggoth.md by removing a space and adds five lines of description to english/forest/drag/skull/skull.md. Please review this, @casey-collab 