### PR TITLE
fix: wrong ss spelling

### DIFF
--- a/german/ruderboot.md
+++ b/german/ruderboot.md
@@ -1,6 +1,6 @@
 Sie wachen von der Sonne geblendet auf und stellen ziemlich benommen fest, dass Sie 
 
-in einem Ruderboot auf einem grossen See treiben. Ihre Hose ist vollkommen durchn‰sst, und
+in einem Ruderboot auf einem groﬂen See treiben. Ihre Hose ist vollkommen durchn‰sst, und
 
 Sie bemerken, dass durch ein Loch in der Bootswand Wasser ins Boot dringt.
 


### PR DESCRIPTION
in german there is a special s-character the 'ß'. 
Sometimes people use 'ss' but in this case that's a spelling error which I am fixing here.