### PR TITLE
fix: use ä instead of ae

### DIFF
--- a/german/Leichen/Leichen.md
+++ b/german/Leichen/Leichen.md
@@ -26,4 +26,4 @@ Irgendwie muss ich versuchen sie los zu werden!
 
 Die Situation scheint meinen Verstand vernebelt zu haben. 
 Die Kälte und das Wasser scheint ihr übriges zu tun. 
-Aber in einem lichten Moment erinnere ich mich an meine [Superkraefte](Superkraefte/Superkraefte.md).
+Aber in einem lichten Moment erinnere ich mich an meine [Superkräfte](Superkraefte/Superkraefte.md).


### PR DESCRIPTION
in german ae is used instead of ä to avoid conflicts with non-ascii characters. But I think it's perfectly fine to use ä in the text for readability.