### PR TITLE
Cages

### DIFF
--- a/Gibberish/HorkPorkDork/horky.md
+++ b/Gibberish/HorkPorkDork/horky.md
@@ -1,2 +1,3 @@
 Horky Porky Dorky Senor Morky Dorky Porky McJorky Forty porty.
 Gesundtite.
+Morky m'larkiboo bada bada boo boo.

--- a/english/zoo/zoo.md
+++ b/english/zoo/zoo.md
@@ -7,5 +7,5 @@ I head over and buy some [lemonade](../drink/lemonade/lemonade.md)
 I choose to get better at [English](../get-better-at-english/english.md)
 
 After my self trolling is complete, I decide to drink the lemonade.
-As I lift the lemonade to my mouth I see the tigers have broken loose.
+As I lift the lemonade to my mouth I see the tigers have escaped their cages!
 [tiger-attack](../tiger-attack/tiger-attack.md)


### PR DESCRIPTION
Did not like 'broken loose'. Replaced, instead, with 'Escaped their Cages'.