### PR TITLE
Fix Udacity course URL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Collaborative Create-Your-Own-Adventure
 
 This is an example repo that illustrates the concept of a "Pull Request", created
-as part of the Udacity course [How to Use Git and GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775).
+as part of the Udacity course [How to Use Git and GitHub](https://classroom.udacity.com/courses/ud775/).
 In the create-your-own-adventure story the reader chooses what action to take and
 turns to an appropriate page of the story based on their choice.  It is collaborative
 because it is written one small piece at a time by many authors.  To start reading


### PR DESCRIPTION
The URL on the README points to what _used to _be__ the correct course address.  Unfortunately that link now redirects to a new totally different course ([Version Control with Git).](https://www.udacity.com/course/version-control-with-git--ud123)  

I am requesting that the README link be (re)pointed towards the proper Udacity course ([How to use Git and GitHub).](https://classroom.udacity.com/courses/ud775/)  

Thanks, 

Huge fan of Udacity courses, and the How to Use Git and GitHub course! 